### PR TITLE
Add missing keyword identifiers to keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,5 +1,5 @@
-MS5637Barometer
-setOSR
-readADC
-readTemperature
-readTCPressure
+MS5637Barometer	KEYWORD1
+setOSR	KEYWORD2
+readADC	KEYWORD2
+readTemperature	KEYWORD2
+readTCPressure	KEYWORD2


### PR DESCRIPTION
Without the identifiers, the keywords are not recognized by the Arduino IDE for special highlighting.